### PR TITLE
Disable file logging by default

### DIFF
--- a/UDF.md
+++ b/UDF.md
@@ -30,6 +30,13 @@ export LANGDB_PROJECT_ID=your_project_id
 export LANGDB_API_KEY=your_api_key
 ```
 
+3. Enable debug log if neccessary. By default, log is sent to stderr. If `UDF_FILE_LOGGING` is set, log is sent to `./logs` folder. 
+
+```bash
+export RUST_LOG="debug"
+export UDF_FILE_LOGGING=true
+```
+
 ## Installation
 
 ```bash

--- a/udfs/src/main.rs
+++ b/udfs/src/main.rs
@@ -161,7 +161,7 @@ async fn process_ordered_futures(
 #[tokio::main]
 async fn main() -> Result<(), InvokeError> {
     // Initialize tracing once at program start
-    if let Err(e) = init_tracing(Some("info")) {
+    if let Err(e) = init_tracing(None) {
         eprintln!("Failed to initialize tracing: {}", e);
     }
 

--- a/udfs/src/tracing.rs
+++ b/udfs/src/tracing.rs
@@ -6,7 +6,14 @@ pub fn get_default_filter(filter: &str) -> String {
 }
 
 pub fn init_tracing(override_env: Option<&str>) -> crate::Result<()> {
-    let debug_file = rolling::minutely("./logs", "logs");
+    let enable_file_logging = std::env::var("UDF_FILE_LOGGING").is_ok();
+    let log_writer = move || -> Box<dyn std::io::Write + Send> {
+    if enable_file_logging {
+        Box::new(rolling::minutely("./logs", "logs"))
+    } else {
+        Box::new(std::io::stderr())
+    }
+    };
 
     let f = tracing_subscriber::fmt::format::Format::default()
         .with_file(true)
@@ -21,14 +28,14 @@ pub fn init_tracing(override_env: Option<&str>) -> crate::Result<()> {
     let stdout_filter = match override_env {
         Some(env) => EnvFilter::try_new(env),
         None => EnvFilter::try_from_default_env()
-            .or_else(|_| EnvFilter::try_new(get_default_filter("udfs=debug"))),
+            .or_else(|_| EnvFilter::try_new(get_default_filter("udfs=error"))),
     }
     .unwrap();
 
     let subscriber = tracing_subscriber::Registry::default().with(
         tracing_subscriber::fmt::Layer::default()
             .event_format(f)
-            .with_writer(debug_file)
+            .with_writer(log_writer)
             .with_filter(stdout_filter),
     );
 


### PR DESCRIPTION
Logging is set to `error` by default and disable file logging because in sandbox environment , the file system is readonly and thus UDF execution would fails.