### PR TITLE
Enhance BedrockError handling by adding specific error variants for timeouts and authentication issues

### DIFF
--- a/core/src/model/error.rs
+++ b/core/src/model/error.rs
@@ -55,7 +55,7 @@ pub enum AuthorizationError {
 
 #[derive(Error, Debug)]
 pub enum ToolError {
-    #[error(" Credentials for '{0}' are invalid or missing")]
+    #[error("Credentials for '{0}' are invalid or missing")]
     CredentialsError(String),
 }
 
@@ -70,11 +70,17 @@ pub enum AnthropicError {
 
 #[derive(Error, Debug)]
 pub enum BedrockError {
-    #[error(" {0:?}")]
+    #[error("Custom Error: {0}")]
     CustomError(String),
 
     #[error("Validation Error: {0}")]
     ValidationError(String),
+
+    #[error("Timeout occurred: {0}")]
+    TimeoutError(String), // Adding a more specific error for timeout issues
+
+    #[error("Invalid credentials: {0}")]
+    AuthenticationError(String), // Adding a specific error for authentication failures
 
     #[error("{}", DisplayErrorContext(.0))]
     SmithyError(
@@ -93,6 +99,7 @@ pub enum BedrockError {
             aws_smithy_runtime_api::http::Response,
         >,
     ),
+    
     #[error("{}", DisplayErrorContext(.0))]
     ResponseError(
         #[from]

--- a/core/src/model/error.rs
+++ b/core/src/model/error.rs
@@ -99,7 +99,7 @@ pub enum BedrockError {
             aws_smithy_runtime_api::http::Response,
         >,
     ),
-    
+
     #[error("{}", DisplayErrorContext(.0))]
     ResponseError(
         #[from]


### PR DESCRIPTION
This pull request introduces improvements to the error handling in the `BedrockError` enum within the `error.rs` file. The goal of this update is to provide more granular and specific error variants for different types of errors that can occur when interacting with AWS Bedrock, enabling easier debugging and better error handling.

#### Changes:
- **Added TimeoutError:** This new error variant specifically handles timeout issues that might arise during AWS Bedrock operations.
- **Added AuthenticationError:** This error variant provides a clear distinction for authentication-related failures, such as invalid credentials or API key issues.
- **Enhanced existing error handling:** The changes make the differentiation between various error types, like timeouts and authentication failures, more explicit, providing better insight into the cause of errors.
  
The updates make it easier for developers to pinpoint the exact nature of the error and take appropriate action accordingly.

#### File Path:
- `core/src/model/error.rs`

Issue Number: #47 